### PR TITLE
Add Egypt name to working docs

### DIFF
--- a/docs/source/working_docs/egypt_name.rst
+++ b/docs/source/working_docs/egypt_name.rst
@@ -53,11 +53,11 @@ RDF as turtle
 
     @prefix relators: <http://id.loc.gov/vocabulary/relators> .
     @prefix ulan: <http://vocab.getty.edu/ulan> .
-    @prefix schema: <https://schema.org/> .
+    @prefix owl: <http://www.w3.org/2002/07/owl#> .
     @prefix foaf: <http://xmlns.com/foaf/spec/> .
 
     <https://example.org/objects/1> relators:pht <https://example.org/name/1> .
 
     <https://example.org/name/1> a foaf:Organization ;
-        schema:sameAs <ulan:500057278> ;
+        owl:sameAs <ulan:500057278> ;
         foaf:name "Bonfils Family"@en .

--- a/docs/source/working_docs/egypt_name.rst
+++ b/docs/source/working_docs/egypt_name.rst
@@ -27,6 +27,8 @@ RDF as turtle
 
     @prefix relators: <http://id.loc.gov/vocabulary/relators> .
     @prefix ulan: <http://vocab.getty.edu/ulan> .
+    @prefix schema: <https://schema.org/> .
+    @prefix foaf: <http://xmlns.com/foaf/spec/> .
 
     <https://example.org/objects/1> relators:pht <https://example.org/names/1> .
 
@@ -41,6 +43,7 @@ RDF as turtle
 
     @prefix relators: <http://id.loc.gov/vocabulary/relators> .
     @prefix ulan: <http://vocab.getty.edu/ulan> .
+    @prefix foaf: <http://xmlns.com/foaf/spec/> .
 
     <https://example.org/objects/1> relators:pht <ulan:500057278> ;
         a foaf:Organization .
@@ -52,6 +55,8 @@ RDF as turtle
 
     @prefix relators: <http://id.loc.gov/vocabulary/relators> .
     @prefix ulan: <http://vocab.getty.edu/ulan> .
+    @prefix schema: <https://schema.org/> .
+    @prefix foaf: <http://xmlns.com/foaf/spec/> .
 
     <https://example.org/objects/1> relators:pht <https://example.org/name/1> .
 

--- a/docs/source/working_docs/egypt_name.rst
+++ b/docs/source/working_docs/egypt_name.rst
@@ -1,0 +1,60 @@
+Modelling name element of Jeune fille du liban coiffée du tentour or egypt:101 to RDF Recommendations
+=====================================================================================================
+
+Given MODS
+----------
+
+.. code-block:: xml
+    :linenos:
+    :caption: Given MODS element
+    :name: Given MODS element
+
+    <name type="corporate" valueURI="http://vocab.getty.edu/ulan/500057278">
+        <namePart>Bonfils family</namePart>
+        <namePart type="date">19th-20th centuries</namePart>
+        <role>
+            <roleTerm type="text" authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/pht">Photographer</roleTerm>
+        </role>
+    </name>
+
+RDF as turtle
+-------------
+
+.. code-block:: turtle
+    :linenos:
+    :caption: Islandora RDF as turtle
+    :name: Islandora RDF as turtle
+
+    @prefix relators: <http://id.loc.gov/vocabulary/relators> .
+    @prefix ulan: <http://vocab.getty.edu/ulan> .
+
+    <https://example.org/objects/1> relators:pht <https://example.org/names/1> .
+
+    <https://example.org/names/1> foaf:name "Bonfils family" ;
+        a foaf:Organization ;
+        schema:sameAs <ulan:500057278> .
+
+.. code-block:: turtle
+    :linenos:
+    :caption: Samvera direct mapping RDF as turtle
+    :name: Samvera Direct Mapping  RDF as turtle
+
+    @prefix relators: <http://id.loc.gov/vocabulary/relators> .
+    @prefix ulan: <http://vocab.getty.edu/ulan> .
+
+    <https://example.org/objects/1> relators:pht <ulan:500057278> ;
+        a foaf:Organization .
+
+.. code-block:: turtle
+    :linenos:
+    :caption: Samvera minted object mapping RDF as turtle
+    :name: Samvera minted object mapping as turtle
+
+    @prefix relators: <http://id.loc.gov/vocabulary/relators> .
+    @prefix ulan: <http://vocab.getty.edu/ulan> .
+
+    <https://example.org/objects/1> relators:pht <https://example.org/name/1> .
+
+    <https://example.org/name/1> a foaf:Organization ;
+        schema:sameAs <ulan:500057278> ;
+        foaf:name "Bonfils Family"@en .

--- a/docs/source/working_docs/egypt_name.rst
+++ b/docs/source/working_docs/egypt_name.rst
@@ -43,10 +43,8 @@ RDF as turtle
 
     @prefix relators: <http://id.loc.gov/vocabulary/relators> .
     @prefix ulan: <http://vocab.getty.edu/ulan> .
-    @prefix foaf: <http://xmlns.com/foaf/spec/> .
 
-    <https://example.org/objects/1> relators:pht <ulan:500057278> ;
-        a foaf:Organization .
+    <https://example.org/objects/1> relators:pht <ulan:500057278> .
 
 .. code-block:: turtle
     :linenos:


### PR DESCRIPTION
This is work collaborated on between the brains of @CanOfBees and @mathewjordan. It's an attempt for us to evaluate the three recommendations (1 Islandora, 2 Samvera) in a focused way on a single element. In this example we focused on **<name>**. 

Note that the `<namePart type="date">19th-20th centuries</namePart>` is not translated to any of the RDF examples. Could have done this in some way?

This won't appear in the updated docs until merged.

https://digital.lib.utk.edu/collections/islandora/object/egypt%3A101/datastream/MODS/view

@mlhale7 @markpbaggett @CanOfBees 