### PR TITLE
Add originInfo to top-level elements assessment

### DIFF
--- a/docs/source/top_level_elements/originInfo_dates.rst
+++ b/docs/source/top_level_elements/originInfo_dates.rst
@@ -71,3 +71,34 @@ The keyDate attribute is always "yes".
 
 dateCreated[@qualifier]
 -----------------------
+
+The qualifier attribute has three distinct values: "inferred", "approximate", and "questionable". It usually appears with other attributes but not always; e.g. `ekcd:95 <https://digital.lib.utk.edu/collections/islandora/object/ekcd:95/datastream/MODS>`_:
+
+.. code-block:: xml
+
+    <originInfo>
+        <dateCreated qualifier="inferred">1955</dateCreated>
+        <dateCreated encoding="edtf" keyDate="yes">1955</dateCreated>
+    </originInfo>
+    <originInfo>
+        <dateCreated>Undated</dateCreated>
+        <dateCreated encoding="edtf" keyDate="yes" point="start" qualifier="inferred">1910</dateCreated>
+        <dateCreated encoding="edtf" keyDate="yes" point="end" qualifier="inferred">1955</dateCreated>
+    </originInfo>
+
+
+dateCreated[@point]
+-------------------
+
+The point attribute has two distinct values: "start" and "end". They are frequently, but not consistently paired; e.g. `volvoices:2152 <https://digital.lib.utk.edu/collections/islandora/object/volvoices%3A2152/datastream/MODS>`_: and `volvoices:3849 <https://digital.lib.utk.edu/collections/islandora/object/volvoices%3A3849/datastream/MODS>`_:
+
+..code-block:: xml
+    <originInfo>
+        <dateCreated>1915</dateCreated>
+        <dateCreated encoding="edtf" keyDate="yes" point="start">1915</dateCreated>
+    </originInfo>
+    <originInfo>
+        <dateCreated>approximately between 1940 and 1950</dateCreated>
+        <dateCreated encoding="edtf" keyDate="yes" point="start" qualifier="approximate">1940</dateCreated>
+        <dateCreated encoding="edtf" keyDate="yes" point="end">1950</dateCreated>
+    </originInfo>

--- a/docs/source/top_level_elements/originInfo_dates.rst
+++ b/docs/source/top_level_elements/originInfo_dates.rst
@@ -27,6 +27,11 @@ dateCreated[@encoding][@keyDate][@point]
       <dateCreated encoding="edtf" keyDate="yes" point="end">1913</dateCreated>
     </originInfo>
 
+.. code-block:: turtle
+
+    @prefix dcterms: <http://purl.org/dc/terms/>
+
+    <https://example.org/objects/1> dcterms:created "1870/1913" .
 
 
 dateCreated[@encoding][@keyDate][@point][@qualifier]
@@ -39,6 +44,12 @@ dateCreated[@encoding][@keyDate][@point][@qualifier]
       <dateCreated encoding="edtf" keyDate="yes" point="start" qualifier="approximate">1900</dateCreated>
       <dateCreated encoding="edtf" keyDate="yes" point="end">1940</dateCreated>
     </originInfo>
+
+.. code-block:: turtle
+
+    @prefix dcterms: <http://purl.org/dc/terms/>
+
+    <https://example.org/objects/1> dcterms:created "1900~/1940" .
 
 
 Attributes on dateCreated
@@ -57,6 +68,12 @@ dateCreated[@encoding] has two distinct values: "edtf" and "w3cdtf". "w3cdtf" ap
     <originInfo>
         <dateCreated encoding="w3cdtf" keyDate="yes" point="start">1941</dateCreated>
     </originInfo>
+
+.. code-block:: turtle
+
+    @prefix dcterms: <http://purl.org/dc/terms/>
+
+    <https://example.org/objects/1> dcterms:created "1910/" .
 
 
 dateCreated[@keyDate]
@@ -86,6 +103,12 @@ The qualifier attribute has three distinct values: "inferred", "approximate", an
         <dateCreated encoding="edtf" keyDate="yes" point="end" qualifier="inferred">1955</dateCreated>
     </originInfo>
 
+.. code-block:: turtle
+
+    @prefix dcterms: <http://purl.org/dc/terms/>
+
+    <https://example.org/objects/1> dcterms:created "1910~/1955~" .
+
 
 dateCreated[@point]
 -------------------
@@ -93,6 +116,7 @@ dateCreated[@point]
 The point attribute has two distinct values: "start" and "end". They are frequently, but not consistently paired; e.g. `volvoices:2152 <https://digital.lib.utk.edu/collections/islandora/object/volvoices%3A2152/datastream/MODS>`_: and `volvoices:3849 <https://digital.lib.utk.edu/collections/islandora/object/volvoices%3A3849/datastream/MODS>`_:
 
 ..code-block:: xml
+
     <originInfo>
         <dateCreated>1915</dateCreated>
         <dateCreated encoding="edtf" keyDate="yes" point="start">1915</dateCreated>
@@ -102,3 +126,9 @@ The point attribute has two distinct values: "start" and "end". They are frequen
         <dateCreated encoding="edtf" keyDate="yes" point="start" qualifier="approximate">1940</dateCreated>
         <dateCreated encoding="edtf" keyDate="yes" point="end">1950</dateCreated>
     </originInfo>
+
+.. code-block:: turtle
+
+    @prefix dcterms: <http://purl.org/dc/terms/>
+
+    <https://example.org/objects/1> dcterms:created "1870/1913" .

--- a/docs/source/top_level_elements/originInfo_dates.rst
+++ b/docs/source/top_level_elements/originInfo_dates.rst
@@ -227,6 +227,8 @@ An example where converting the string value would be necessary: `kintner:56 <ht
 
     <https://example.org/objects/1> dcterms:date "1974-12-10" .
 
+The Archivision collection uses `dateOther` to indicate dates of remodeling or architectural changes.
+
 .. code-block:: xml
 
     <originInfo>

--- a/docs/source/top_level_elements/originInfo_dates.rst
+++ b/docs/source/top_level_elements/originInfo_dates.rst
@@ -162,7 +162,7 @@ The point attribute has two distinct values: "start" and "end". They are frequen
 dateIssued
 ----------
 
-`dateIssued`'s attributes and possible values follow the examples in `dateCreated` very closely. The primary difference between the two is that `dateIssued` is used in records describing serials.
+`dateIssued`'s attributes and possible values follow the examples in `dateCreated` very closely. `dateIssued` is broadly used to describe published materials: serials, sheet music, and others.
 
 dateIssued[@encoding][@keyDate][@point][@qualifier]
 ---------------------------------------------------

--- a/docs/source/top_level_elements/originInfo_dates.rst
+++ b/docs/source/top_level_elements/originInfo_dates.rst
@@ -143,3 +143,35 @@ The point attribute has two distinct values: "start" and "end". They are frequen
     @prefix dcterms: <http://purl.org/dc/terms/>
 
     <https://example.org/objects/1> dcterms:created "1940~/1950" .
+
+dateIssued
+----------
+
+`dateIssued`'s attributes and possible values follow the examples in `dateCreated` very closely. The primary difference between the two is that `dateIssued` is used in records describing serials.
+
+dateIssued[@encoding][@keyDate][@point][@qualifier]
+---------------------------------------------------
+
+
+dateOther
+---------
+
+
+copyrightDate
+-------------
+
+This value appears once in our MODS, in `calahan:1 <https://digital.lib.utk.edu/collections/islandora/object/calahan%3A1>`_:
+
+..code-block:: xml
+
+    <originInfo>
+        <dateCreated>undated</dateCreated>
+        <copyrightDate>1941</copyrightDate>
+    </originInfo>
+
+..code-block:: turtle
+
+    @prefix dcterms: <http://purl.org/dc/terms/>
+
+    <https://example.org/objects/1> dcterms:created "undated" ;
+        dcterms:dateCopyrighted "1941" .

--- a/docs/source/top_level_elements/originInfo_dates.rst
+++ b/docs/source/top_level_elements/originInfo_dates.rst
@@ -45,17 +45,22 @@ Attributes on dateCreated
 -------------------------
 
 dateCreated[@encoding]
----------
+----------------------
 
-dateCreated[@encoding] has two distinct values:
+dateCreated[@encoding] has two distinct values: "edtf" and "w3cdtf". "w3cdtf" appears in a smaller number of records; e.g. `arrowmont:698 <https://digital.lib.utk.edu/collections/islandora/object/arrowmont%3A698/datastream/MODS>`_:
 
 .. code-block:: xml
 
-    <dateCreated encoding="edtf"/>
-    <dateCreated encoding="w3cdtf"/>
+    <originInfo>
+        <dateCreated encoding="edtf" keyDate="yes" point="start">1910</dateCreated>
+    </originInfo>
+    <originInfo>
+        <dateCreated encoding="w3cdtf" keyDate="yes" point="start">1941</dateCreated>
+    </originInfo>
 
-@keyDate
---------
+
+dateCreated[@keyDate]
+---------------------
 
 The keyDate attribute is always "yes".
 
@@ -64,4 +69,5 @@ The keyDate attribute is always "yes".
     @keyDate = "yes"
 
 
-
+dateCreated[@qualifier]
+-----------------------

--- a/docs/source/top_level_elements/originInfo_dates.rst
+++ b/docs/source/top_level_elements/originInfo_dates.rst
@@ -211,6 +211,39 @@ An example of multiple date elements, `volvoices:2993 <https://digital.lib.utk.e
 dateOther
 ---------
 
+dateOther is rarely used (it appears in ~2700 records).
+
+An example where converting the string value would be necessary: `kintner:56 <https://digital.lib.utk.edu/collections/islandora/object/kintner%3A56>`_:
+
+.. code-block:: xml
+
+    <originInfo>
+        <dateOther>1974 December 10</dateOther>
+    </originInfo>
+
+.. code-block:: turtle
+
+    @prefix dcterms: <http://purl.org/dc/terms/>
+
+    <https://example.org/objects/1> dcterms:date "1974-12-10" .
+
+.. code-block:: xml
+
+    <originInfo>
+        <publisher>Archivision, Inc.</publisher>
+        <dateCreated>founded 314; rebuilt and remodelled between 440-1885</dateCreated>
+        <dateCreated encoding="edtf" keyDate="yes">314</dateCreated>
+        <dateOther encoding="edtf" point="start">440</dateOther>
+        <dateOther encoding="edtf" point="end">1885</dateOther>
+    </originInfo>
+
+.. code-block:: turtle
+
+    @prefix dcterms: <http://purl.org/dc/terms/>
+
+    <https://example.org/objects/1> dcterms:created "314" ;
+        dcterms:date "440/1885" .
+
 
 copyrightDate
 -------------

--- a/docs/source/top_level_elements/originInfo_dates.rst
+++ b/docs/source/top_level_elements/originInfo_dates.rst
@@ -1,0 +1,67 @@
+originInfo: dates
+=================
+
+About
+-----
+
+This section describes all of the different subelements of originInfo in our MODS.
+
+Dates
+-----
+
+We have three different date-related subelements: dateCreated, dateIssued, and dateOther.
+
+dateCreated
+-----------
+
+dateCreated has the widest range of possible values and attributes.
+
+dateCreated[@encoding][@keyDate][@point]
+----------------------------------------
+
+.. code-block:: xml
+
+    <originInfo>
+      <dateCreated>1870-1913</dateCreated>
+      <dateCreated encoding="edtf" keyDate="yes" point="start">1870</dateCreated>
+      <dateCreated encoding="edtf" keyDate="yes" point="end">1913</dateCreated>
+    </originInfo>
+
+
+
+dateCreated[@encoding][@keyDate][@point][@qualifier]
+----------------------------------------------------
+
+.. code-block:: xml
+
+    <originInfo>
+      <dateCreated>approximately between 1900 and 1940</dateCreated>
+      <dateCreated encoding="edtf" keyDate="yes" point="start" qualifier="approximate">1900</dateCreated>
+      <dateCreated encoding="edtf" keyDate="yes" point="end">1940</dateCreated>
+    </originInfo>
+
+
+Attributes on dateCreated
+-------------------------
+
+dateCreated[@encoding]
+---------
+
+dateCreated[@encoding] has two distinct values:
+
+.. code-block:: xml
+
+    <dateCreated encoding="edtf"/>
+    <dateCreated encoding="w3cdtf"/>
+
+@keyDate
+--------
+
+The keyDate attribute is always "yes".
+
+.. code-block:: xml
+
+    @keyDate = "yes"
+
+
+

--- a/docs/source/top_level_elements/originInfo_dates.rst
+++ b/docs/source/top_level_elements/originInfo_dates.rst
@@ -9,7 +9,7 @@ This section describes all of the different subelements of originInfo in our MOD
 Dates
 -----
 
-We have three different date-related subelements: dateCreated, dateIssued, and dateOther.
+We have four different date-related subelements: dateCreated, dateIssued, dateOther, and copyrightDate.
 
 dateCreated
 -----------

--- a/docs/source/top_level_elements/originInfo_dates.rst
+++ b/docs/source/top_level_elements/originInfo_dates.rst
@@ -65,6 +65,9 @@ dateCreated[@encoding] has two distinct values: "edtf" and "w3cdtf". "w3cdtf" ap
     <originInfo>
         <dateCreated encoding="edtf" keyDate="yes" point="start">1910</dateCreated>
     </originInfo>
+
+.. code-block:: xml
+
     <originInfo>
         <dateCreated encoding="w3cdtf" keyDate="yes" point="start">1941</dateCreated>
     </originInfo>
@@ -73,7 +76,13 @@ dateCreated[@encoding] has two distinct values: "edtf" and "w3cdtf". "w3cdtf" ap
 
     @prefix dcterms: <http://purl.org/dc/terms/>
 
-    <https://example.org/objects/1> dcterms:created "1910/" .
+    <https://example.org/objects/1> dcterms:created "1910" .
+
+.. code-block:: turtle
+
+    @prefix dcterms: <http://purl.org/dc/terms/>
+
+    <https://example.org/objects/1> dcterms:created "1941" .
 
 
 dateCreated[@keyDate]
@@ -97,6 +106,9 @@ The qualifier attribute has three distinct values: "inferred", "approximate", an
         <dateCreated qualifier="inferred">1955</dateCreated>
         <dateCreated encoding="edtf" keyDate="yes">1955</dateCreated>
     </originInfo>
+
+.. code-block:: xml
+
     <originInfo>
         <dateCreated>Undated</dateCreated>
         <dateCreated encoding="edtf" keyDate="yes" point="start" qualifier="inferred">1910</dateCreated>

--- a/docs/source/top_level_elements/originInfo_dates.rst
+++ b/docs/source/top_level_elements/originInfo_dates.rst
@@ -120,7 +120,7 @@ dateCreated[@point]
 
 The point attribute has two distinct values: "start" and "end". They are frequently, but not consistently paired; e.g. `volvoices:2152 <https://digital.lib.utk.edu/collections/islandora/object/volvoices%3A2152/datastream/MODS>`_: and `volvoices:3849 <https://digital.lib.utk.edu/collections/islandora/object/volvoices%3A3849/datastream/MODS>`_:
 
-..code-block:: xml
+.. code-block:: xml
 
     <originInfo>
         <dateCreated>1915</dateCreated>
@@ -162,14 +162,14 @@ copyrightDate
 
 This value appears once in our MODS, in `calahan:1 <https://digital.lib.utk.edu/collections/islandora/object/calahan%3A1>`_:
 
-..code-block:: xml
+.. code-block:: xml
 
     <originInfo>
         <dateCreated>undated</dateCreated>
         <copyrightDate>1941</copyrightDate>
     </originInfo>
 
-..code-block:: turtle
+.. code-block:: turtle
 
     @prefix dcterms: <http://purl.org/dc/terms/>
 

--- a/docs/source/top_level_elements/originInfo_dates.rst
+++ b/docs/source/top_level_elements/originInfo_dates.rst
@@ -152,6 +152,61 @@ dateIssued
 dateIssued[@encoding][@keyDate][@point][@qualifier]
 ---------------------------------------------------
 
+.. code-block:: xml
+
+    <originInfo>
+        <dateIssued>1934</dateIssued>
+        <dateIssued encoding="edtf" keyDate="yes">1934</dateIssued>
+    </originInfo>
+
+.. code-block:: turtle
+
+    @prefix dcterms: <http://purl.org/dc/terms/>
+
+    <https://example.org/objects/1> dcterms:issued "1934" .
+
+.. code-block:: xml
+
+    <originInfo>
+        <dateIssued>1989</dateIssued>
+        <dateIssued encoding="edtf">1989-23</dateIssued>
+    </originInfo>
+
+.. code-block:: turtle
+
+    @prefix dcterms: <http://purl.org/dc/terms/>
+
+    <https://example.org/objects/1> dcterms:issued "1989-23" . # display as 'Spring, 1989'
+
+.. code-block:: xml
+
+    <originInfo>
+        <dateIssued qualifier="approximate">1954</dateIssued>
+        <dateIssued encoding="edtf" keyDate="yes" qualifier="approximate">1954</dateIssued>
+    </originInfo>
+
+.. code-block:: turtle
+
+    @prefix dcterms: <http://purl.org/dc/terms/>
+
+    <https://example.org/objects/1> dcterms:issued "1954~" .
+
+An example of multiple date elements, `volvoices:2993 <https://digital.lib.utk.edu/collections/islandora/object/volvoices%3A2993>`:_
+
+.. code-block:: xml
+
+    <originInfo>
+      <dateCreated>1948-01</dateCreated>
+      <dateCreated encoding="edtf" keyDate="yes">1948-01</dateCreated>
+      <dateIssued encoding="edtf" keyDate="yes" qualifier="approximate">1948</dateIssued>
+    </originInfo>
+
+.. code-block:: turtle
+
+    @prefix dcterms: <http://purl.org/dc/terms/>
+
+    <https://example.org/objects/1> dcterms:created "1948-01" ;
+        dcterms:issued "1948~" .
 
 dateOther
 ---------

--- a/docs/source/top_level_elements/originInfo_dates.rst
+++ b/docs/source/top_level_elements/originInfo_dates.rst
@@ -31,7 +31,7 @@ dateCreated[@encoding][@keyDate][@point]
 
     @prefix dcterms: <http://purl.org/dc/terms/>
 
-    <https://example.org/objects/1> dcterms:created "1870/1913" .
+    <https://example.org/objects/1> dcterms:created "1870-1913", "1870/1913" .
 
 
 dateCreated[@encoding][@keyDate][@point][@qualifier]
@@ -49,7 +49,7 @@ dateCreated[@encoding][@keyDate][@point][@qualifier]
 
     @prefix dcterms: <http://purl.org/dc/terms/>
 
-    <https://example.org/objects/1> dcterms:created "1900~/1940" .
+    <https://example.org/objects/1> dcterms:created "approximately between 1900 and 1940", "1900~/1940" .
 
 
 Attributes on dateCreated
@@ -66,17 +66,17 @@ dateCreated[@encoding] has two distinct values: "edtf" and "w3cdtf". "w3cdtf" ap
         <dateCreated encoding="edtf" keyDate="yes" point="start">1910</dateCreated>
     </originInfo>
 
-.. code-block:: xml
-
-    <originInfo>
-        <dateCreated encoding="w3cdtf" keyDate="yes" point="start">1941</dateCreated>
-    </originInfo>
-
 .. code-block:: turtle
 
     @prefix dcterms: <http://purl.org/dc/terms/>
 
     <https://example.org/objects/1> dcterms:created "1910" .
+
+.. code-block:: xml
+
+    <originInfo>
+        <dateCreated encoding="w3cdtf" keyDate="yes" point="start">1941</dateCreated>
+    </originInfo>
 
 .. code-block:: turtle
 
@@ -107,6 +107,12 @@ The qualifier attribute has three distinct values: "inferred", "approximate", an
         <dateCreated encoding="edtf" keyDate="yes">1955</dateCreated>
     </originInfo>
 
+.. code-block:: turtle
+
+    @prefix dcterms: <http://purl.org/dc/terms/>
+
+    <https://example.org/objects/1> dcterms:created "1955", "1955~" .
+
 .. code-block:: xml
 
     <originInfo>
@@ -119,13 +125,7 @@ The qualifier attribute has three distinct values: "inferred", "approximate", an
 
     @prefix dcterms: <http://purl.org/dc/terms/>
 
-    <https://example.org/objects/1> dcterms:created "1955~" .
-
-.. code-block:: turtle
-
-    @prefix dcterms: <http://purl.org/dc/terms/>
-
-    <https://example.org/objects/1> dcterms:created "1910~/1955~" .
+    <https://example.org/objects/1> dcterms:created "Undated", "1910~/1955~" .
 
 dateCreated[@point]
 -------------------
@@ -138,6 +138,15 @@ The point attribute has two distinct values: "start" and "end". They are frequen
         <dateCreated>1915</dateCreated>
         <dateCreated encoding="edtf" keyDate="yes" point="start">1915</dateCreated>
     </originInfo>
+
+.. code-block:: turtle
+
+    @prefix dcterms: <http://purl.org/dc/terms/>
+
+    <https://example.org/objects/1> dcterms:created "1915", "1915/" .
+
+.. code-block:: xml
+
     <originInfo>
         <dateCreated>approximately between 1940 and 1950</dateCreated>
         <dateCreated encoding="edtf" keyDate="yes" point="start" qualifier="approximate">1940</dateCreated>
@@ -148,13 +157,7 @@ The point attribute has two distinct values: "start" and "end". They are frequen
 
     @prefix dcterms: <http://purl.org/dc/terms/>
 
-    <https://example.org/objects/1> dcterms:created "1915/" .
-
-.. code-block:: turtle
-
-    @prefix dcterms: <http://purl.org/dc/terms/>
-
-    <https://example.org/objects/1> dcterms:created "1940~/1950" .
+    <https://example.org/objects/1> dcterms:created "approximately between 1940 and 1950", "1940~/1950" .
 
 dateIssued
 ----------
@@ -175,7 +178,7 @@ dateIssued[@encoding][@keyDate][@point][@qualifier]
 
     @prefix dcterms: <http://purl.org/dc/terms/>
 
-    <https://example.org/objects/1> dcterms:issued "1934" .
+    <https://example.org/objects/1> dcterms:issued "1934", "1934" .
 
 .. code-block:: xml
 
@@ -188,7 +191,7 @@ dateIssued[@encoding][@keyDate][@point][@qualifier]
 
     @prefix dcterms: <http://purl.org/dc/terms/>
 
-    <https://example.org/objects/1> dcterms:issued "1989-23" . # display as 'Spring, 1989'
+    <https://example.org/objects/1> dcterms:issued "1989", "1989-23" . # display as 'Spring, 1989'
 
 .. code-block:: xml
 
@@ -201,7 +204,7 @@ dateIssued[@encoding][@keyDate][@point][@qualifier]
 
     @prefix dcterms: <http://purl.org/dc/terms/>
 
-    <https://example.org/objects/1> dcterms:issued "1954~" .
+    <https://example.org/objects/1> dcterms:issued "1954", "1954~" .
 
 An example of multiple date elements, `volvoices:2993 <https://digital.lib.utk.edu/collections/islandora/object/volvoices%3A2993>`:_
 
@@ -217,7 +220,7 @@ An example of multiple date elements, `volvoices:2993 <https://digital.lib.utk.e
 
     @prefix dcterms: <http://purl.org/dc/terms/>
 
-    <https://example.org/objects/1> dcterms:created "1948-01" ;
+    <https://example.org/objects/1> dcterms:created "1948-01", "1948-01" ;
         dcterms:issued "1948~" .
 
 dateOther
@@ -237,7 +240,7 @@ An example where converting the string value would be necessary: `kintner:56 <ht
 
     @prefix dcterms: <http://purl.org/dc/terms/>
 
-    <https://example.org/objects/1> dcterms:date "1974-12-10" .
+    <https://example.org/objects/1> dcterms:date "1974-12-10", "1974 December 10" . # keep the original value; possibly preprocess the data to normalized format.
 
 The Archivision collection uses `dateOther` to indicate dates of remodeling or architectural changes.
 

--- a/docs/source/top_level_elements/originInfo_dates.rst
+++ b/docs/source/top_level_elements/originInfo_dates.rst
@@ -71,3 +71,23 @@ The keyDate attribute is always "yes".
 
 dateCreated[@qualifier]
 -----------------------
+
+The qualifier attribute has three distinct values: "inferred", "approximate", and "questionable". It usually appears with other attributes but not always; e.g. `ekcd:95 <https://digital.lib.utk.edu/collections/islandora/object/ekcd:95/datastream/MODS>`_:
+
+.. code-block:: xml
+
+    <originInfo>
+        <dateCreated qualifier="inferred">1955</dateCreated>
+        <dateCreated encoding="edtf" keyDate="yes">1955</dateCreated>
+    </originInfo>
+    <originInfo>
+        <dateCreated>Undated</dateCreated>
+        <dateCreated encoding="edtf" keyDate="yes" point="start" qualifier="inferred">1910</dateCreated>
+        <dateCreated encoding="edtf" keyDate="yes" point="end" qualifier="inferred">1955</dateCreated>
+    </originInfo>
+
+
+dateCreated[@point]
+-------------------
+
+The point attribute has two distinct values: "start" and "end". They are not evenly paired.

--- a/docs/source/top_level_elements/originInfo_publishing.rst
+++ b/docs/source/top_level_elements/originInfo_publishing.rst
@@ -46,10 +46,52 @@ An example, `utsmc:13759 <https://digital.lib.utk.edu/collections/islandora/obje
 place
 -----
 
+.. code-block:: xml
+
+    <originInfo>
+        <place supplied="yes">
+            <placeTerm type="text" valueURI="http://id.loc.gov/authorities/names/n79072935">Meadville (Crawford County, Pa.)</placeTerm>
+        </place>
+        <publisher>Keystone View Company</publisher>
+        <dateCreated>between 1890 and 1930?</dateCreated>
+        <dateCreated encoding="edtf" keyDate="yes" point="start" qualifier="questionable">1890</dateCreated>
+        <dateCreated encoding="edtf" keyDate="yes" point="end">1930</dateCreated>
+    </originInfo>
+
+.. code-block:: turtle
+
+    @prefix relators: <http://id.loc.gov/vocabulary/relators>
+    @prefix dcterms: <http://purl.org/dc/terms/>
+
+    <https://example.org/objects/1> relators:pbl "Keystone View Company" ;
+        relators:pup <http://id.loc.gov/authorities/names/n79072935> ;
+        dcterms:created "between 1890 and 1930?", "1890?/1930" .
+
+There are problematic uses of `place` in `collections:sanborn` (empty elements).
+
+.. code-block:: xml
+
+  <originInfo>
+    <place supplied="yes">
+      <placeTerm type="text"/>
+    </place>
+    <publisher>Sanborn Map &amp; Publishing Co., Ltd</publisher>
+    <dateCreated>1917</dateCreated>
+    <dateCreated encoding="edtf" keyDate="yes">1917</dateCreated>
+  </originInfo>
+
+.. code-block:: turtle
+
+    @prefix relators: <http://id.loc.gov/vocabulary/relators>
+    @prefix dcterms: <http://purl.org/dc/terms/>
+
+    <https://example.org/objects/1> relators:pbl "Sanborn Map & Publishing Co., Ltd" ;
+        dcterms:created "1917", "1917" .
+
 issuance
 --------
 
-The `issuance` element appears 4207 times and the value is always "serial".
+The `issuance` element appears 4207 times and the value is always "serial". We will not migrate `issuance`.
 
 .. code-block:: xml
 

--- a/docs/source/top_level_elements/originInfo_publishing.rst
+++ b/docs/source/top_level_elements/originInfo_publishing.rst
@@ -41,7 +41,7 @@ An example, `utsmc:13759 <https://digital.lib.utk.edu/collections/islandora/obje
     @prefix dcterms: <http://purl.org/dc/terms/>
 
     <https://example.org/objects/1> relators:pbl "Archivision, Inc." ;
-        dcterms:created "1665/" .
+        dcterms:created "begun 1665", "1665" .
 
 place
 -----

--- a/docs/source/top_level_elements/originInfo_publishing.rst
+++ b/docs/source/top_level_elements/originInfo_publishing.rst
@@ -1,0 +1,25 @@
+originInfo: publishing information
+==================================
+
+About
+-----
+
+This section describes the non-date specific subelements of originInfo in our MODS.
+
+publisher
+---------
+
+place
+-----
+
+issuance
+--------
+
+The `issuance` element appears 4207 times and the value is always "serial".
+
+.. code-block:: xml
+
+    <issuance>serial</issuance>
+
+
+

--- a/docs/source/top_level_elements/originInfo_publishing.rst
+++ b/docs/source/top_level_elements/originInfo_publishing.rst
@@ -9,6 +9,40 @@ This section describes the non-date specific subelements of originInfo in our MO
 publisher
 ---------
 
+An example, `utsmc:13759 <https://digital.lib.utk.edu/collections/islandora/object/utsmc%3A13759>`_:
+
+.. code-block:: xml
+
+    <originInfo>
+        <place>
+            <placeTerm valueURI="http://id.loc.gov/authorities/names/n79006530">Baltimore (Md.)</placeTerm>
+        </place>
+        <publisher>Frederick D. Benteen</publisher>
+    </originInfo>
+
+.. code-block:: turtle
+
+    @prefix relators: <http://id.loc.gov/vocabulary/relators>
+
+    <https://example.org/objects/1> relators:pbl "Frederick D. Benteen" ;
+        relators:pup <http://id.loc.gov/authorities/names/n79006530> .
+
+.. code-block:: xml
+
+    <originInfo>
+      <publisher>Archivision, Inc.</publisher>
+      <dateCreated>begun 1665</dateCreated>
+      <dateCreated encoding="edtf" keyDate="yes">1665</dateCreated>
+    </originInfo>
+
+.. code-block:: turtle
+
+    @prefix relators: <http://id.loc.gov/vocabulary/relators>
+    @prefix dcterms: <http://purl.org/dc/terms/>
+
+    <https://example.org/objects/1> relators:pbl "Archivision, Inc." ;
+        dcterms:created "1665/" .
+
 place
 -----
 


### PR DESCRIPTION
This PR adds originInfo examples to our top-level elements.