### PR TITLE
Build on push

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,16 @@
+name: Test Builds on Push
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - name: Install Sphinx
+        run: sudo apt-get install python3-sphinx
+      - name: Install our application with pipenv
+        uses: VaultVulp/action-pipenv@v2.0.1
+        with:
+          command: install -d
+      - name: Make HTML
+        run: cd docs && make html

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # UT Libraries MODS to RDF Mapping
 
 ![readthedocs icon](https://readthedocs.org/projects/utk-mods-to-rdf/badge/?version=latest)
+![Test Builds on Push](https://github.com/UTKcataloging/mods_to_rdf/workflows/Test%20Builds%20on%20Push/badge.svg)
 
 A repository that contains work related to UT Libraries MODS to RDF mapping and code to generate documentation at
 [UTK MODS to RDF](https://utk-mods-to-rdf.readthedocs.io/en/latest/).


### PR DESCRIPTION
What Does This Do
===============

Adds an action to test Sphinx builds on push regardless on branch.  The build is based on our [make file](https://github.com/UTKcataloging/mods_to_rdf/blob/master/docs/Makefile) for building out html docs only.  If it builds without error, the build passes.  If it doesn't, fails. **Note**: our make file states to treat warnings as errors.