### PR TITLE
Add language analysis.

### DIFF
--- a/docs/source/top_level_elements/language.rst
+++ b/docs/source/top_level_elements/language.rst
@@ -18,7 +18,7 @@ https://digital.lib.utk.edu/collections/islandora/object/tatum%3A188/datastream/
 
 .. code-block:: turtle
 
-    @prefix dcterms: <http://purl.org/dc/terms/>
+    @prefix dcterms: <http://purl.org/dc/terms/> .
 
     <https://example.org/objects/1> dcterms:language <http://id.loc.gov/vocabulary/iso639-2/eng> .
 
@@ -35,7 +35,7 @@ https://digital.lib.utk.edu/collections/islandora/object/ekcd:9/datastream/MODS/
 
 .. code-block:: turtle
 
-    @prefix dcterms: <http://purl.org/dc/terms/>
+    @prefix dcterms: <http://purl.org/dc/terms/> .
 
     <https://example.org/objects/1> dcterms:language <http://id.loc.gov/vocabulary/iso639-2/eng> .
 
@@ -57,7 +57,7 @@ https://digital.lib.utk.edu/collections/islandora/object/utsmc:725/datastream/MO
 
 .. code-block:: turtle
 
-    @prefix dcterms: <http://purl.org/dc/terms/>
+    @prefix dcterms: <http://purl.org/dc/terms/> .
 
     <https://example.org/objects/1>
         dcterms:language <http://id.loc.gov/vocabulary/iso639-2/fre> ;
@@ -78,7 +78,7 @@ https://digital.lib.utk.edu/collections/islandora/object/egypt:59/datastream/MOD
 
 .. code-block:: turtle
 
-    @prefix dcterms: <http://purl.org/dc/terms/>
+    @prefix dcterms: <http://purl.org/dc/terms/> .
 
     <https://example.org/objects/1>
         dcterms:language <http://id.loc.gov/vocabulary/iso639-2/eng> ;
@@ -97,7 +97,7 @@ https://digital.lib.utk.edu/collections/islandora/object/tdh:911/datastream/MODS
 
 .. code-block:: turtle
 
-    @prefix dcterms: <http://purl.org/dc/terms/>
+    @prefix dcterms: <http://purl.org/dc/terms/> .
 
     <https://example.org/objects/1> dcterms:language <http://id.loc.gov/vocabulary/iso639-2/zxx> ;
 
@@ -114,7 +114,7 @@ https://digital.lib.utk.edu/collections/islandora/object/tdh:911/datastream/MODS
 
 .. code-block:: turtle
 
-    @prefix dcterms: <http://purl.org/dc/terms/>
+    @prefix dcterms: <http://purl.org/dc/terms/> .
 
     <https://example.org/objects/1> dcterms:language <http://id.loc.gov/vocabulary/iso639-2/zxx> ;
 
@@ -138,7 +138,7 @@ https://digital.lib.utk.edu/collections/islandora/object/volvoices:9928/datastre
 
 .. code-block:: turtle
 
-    @prefix dcterms: <http://purl.org/dc/terms/>
+    @prefix dcterms: <http://purl.org/dc/terms/> .
 
     <https://example.org/objects/1> dcterms:language <http://id.loc.gov/vocabulary/iso639-2/fre> ;
 
@@ -162,7 +162,7 @@ to migrate.
 
 .. code-block:: turtle
 
-    @prefix dcterms: <http://purl.org/dc/terms/>
+    @prefix dcterms: <http://purl.org/dc/terms/> .
 
     <https://example.org/objects/1>
         dcterms:language <http://id.loc.gov/vocabulary/iso639-2/eng> ;

--- a/docs/source/top_level_elements/language.rst
+++ b/docs/source/top_level_elements/language.rst
@@ -2,11 +2,14 @@ language
 ========
 
 About
-_____
+-----
 This section describes all the different types of language elements that we have in our Islandora repository right now.
 
+Distinct Cases
+--------------
+
 language has languageTerm subelement with an @authority of "iso639-2b" and a @type of "text"
---------------------------------------------------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 https://digital.lib.utk.edu/collections/islandora/object/tatum%3A188/datastream/MODS/view
 
@@ -23,7 +26,7 @@ https://digital.lib.utk.edu/collections/islandora/object/tatum%3A188/datastream/
     <https://example.org/objects/1> dcterms:language <http://id.loc.gov/vocabulary/iso639-2/eng> .
 
 language has languageTerm subelement with an @authority of "iso639-2b" and a @type of "code"
---------------------------------------------------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 https://digital.lib.utk.edu/collections/islandora/object/ekcd:9/datastream/MODS/view
 
@@ -40,7 +43,7 @@ https://digital.lib.utk.edu/collections/islandora/object/ekcd:9/datastream/MODS/
     <https://example.org/objects/1> dcterms:language <http://id.loc.gov/vocabulary/iso639-2/eng> .
 
 language has multiple elements
-------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Present for 11 total in utsmc
 
@@ -85,7 +88,7 @@ https://digital.lib.utk.edu/collections/islandora/object/egypt:59/datastream/MOD
         dcterms:language <http://id.loc.gov/vocabulary/iso639-2/fre> .
 
 language has language subelement with an @type of #text and value of "No linguistic content"
---------------------------------------------------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 https://digital.lib.utk.edu/collections/islandora/object/tdh:911/datastream/MODS/view
 
@@ -99,10 +102,10 @@ https://digital.lib.utk.edu/collections/islandora/object/tdh:911/datastream/MODS
 
     @prefix dcterms: <http://purl.org/dc/terms/> .
 
-    <https://example.org/objects/1> dcterms:language <http://id.loc.gov/vocabulary/iso639-2/zxx> ;
+    <https://example.org/objects/1> dcterms:language <http://id.loc.gov/vocabulary/iso639-2/zxx> .
 
 language has language subelement with an @type = "code" and value of "zxx"
---------------------------------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 https://digital.lib.utk.edu/collections/islandora/object/tdh:911/datastream/MODS/view
 
@@ -116,19 +119,19 @@ https://digital.lib.utk.edu/collections/islandora/object/tdh:911/datastream/MODS
 
     @prefix dcterms: <http://purl.org/dc/terms/> .
 
-    <https://example.org/objects/1> dcterms:language <http://id.loc.gov/vocabulary/iso639-2/zxx> ;
+    <https://example.org/objects/1> dcterms:language <http://id.loc.gov/vocabulary/iso639-2/zxx> .
 
 
 
 language has language subelement without a stated @authority and a @code value of "fra"
----------------------------------------------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Two questions here along with my proposed:
 
 1. How do we handle any that have no stated authority?
 2. Two volvoices objects use "fra". Is there a difference between fra and fre as codes?
 
-https://digital.lib.utk.edu/collections/islandora/object/volvoices:9928/datastream/MODS/vieww
+https://digital.lib.utk.edu/collections/islandora/object/volvoices:9928/datastream/MODS/view
 
 .. code-block:: xml
 
@@ -140,10 +143,10 @@ https://digital.lib.utk.edu/collections/islandora/object/volvoices:9928/datastre
 
     @prefix dcterms: <http://purl.org/dc/terms/> .
 
-    <https://example.org/objects/1> dcterms:language <http://id.loc.gov/vocabulary/iso639-2/fre> ;
+    <https://example.org/objects/1> dcterms:language <http://id.loc.gov/vocabulary/iso639-2/fre> .
 
 Special Note
-------------
+^^^^^^^^^^^^
 https://digital.lib.utk.edu/collections/islandora/object/collections:utsmc/datastream/MODS/view
 
 The collection object for utsmc has the follow language XML. While it may not matter with it being a

--- a/docs/source/top_level_elements/language.rst
+++ b/docs/source/top_level_elements/language.rst
@@ -1,0 +1,172 @@
+language
+========
+
+About
+_____
+This section describes all the different types of language elements that we have in our Islandora repository right now.
+
+language has languageTerm subelement with an @authority of "iso639-2b" and a @type of "text"
+--------------------------------------------------------------------------------------------
+
+https://digital.lib.utk.edu/collections/islandora/object/tatum%3A188/datastream/MODS/view
+
+.. code-block:: xml
+
+    <language>
+        <languageTerm authority="iso639-2b" type="text">English</languageTerm>
+    </language>
+
+.. code-block:: turtle
+
+    @prefix dcterms: <http://purl.org/dc/terms/>
+
+    <https://example.org/objects/1> dcterms:language <http://id.loc.gov/vocabulary/iso639-2/eng> .
+
+language has languageTerm subelement with an @authority of "iso639-2b" and a @type of "code"
+--------------------------------------------------------------------------------------------
+
+https://digital.lib.utk.edu/collections/islandora/object/ekcd:9/datastream/MODS/view
+
+.. code-block:: xml
+
+    <language>
+        <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+    </language>
+
+.. code-block:: turtle
+
+    @prefix dcterms: <http://purl.org/dc/terms/>
+
+    <https://example.org/objects/1> dcterms:language <http://id.loc.gov/vocabulary/iso639-2/eng> .
+
+language has multiple elements
+------------------------------
+
+Present for 11 total in utsmc
+
+https://digital.lib.utk.edu/collections/islandora/object/utsmc:725/datastream/MODS/view
+
+.. code-block:: xml
+
+    <language>
+        <languageTerm authority="iso639-2b" type="text">French</languageTerm>
+    </language>
+    <language>
+        <languageTerm authority="iso639-2b" type="text">Italian</languageTerm>
+    </language>
+
+.. code-block:: turtle
+
+    @prefix dcterms: <http://purl.org/dc/terms/>
+
+    <https://example.org/objects/1>
+        dcterms:language <http://id.loc.gov/vocabulary/iso639-2/fre> ;
+        dcterms:language <http://id.loc.gov/vocabulary/iso639-2/ita> .
+
+Present for 1 total in egypt
+
+https://digital.lib.utk.edu/collections/islandora/object/egypt:59/datastream/MODS/view
+
+.. code-block:: xml
+
+    <language>
+        <languageTerm type="code" authority="iso639-2b">eng</languageTerm>
+    </language>
+    <language>
+        <languageTerm type="code" authority="iso639-2b">fre</languageTerm>
+    </language>
+
+.. code-block:: turtle
+
+    @prefix dcterms: <http://purl.org/dc/terms/>
+
+    <https://example.org/objects/1>
+        dcterms:language <http://id.loc.gov/vocabulary/iso639-2/eng> ;
+        dcterms:language <http://id.loc.gov/vocabulary/iso639-2/fre> .
+
+language has language subelement with an @type of #text and value of "No linguistic content"
+--------------------------------------------------------------------------------------------
+
+https://digital.lib.utk.edu/collections/islandora/object/tdh:911/datastream/MODS/view
+
+.. code-block:: xml
+
+    <language>
+        <languageTerm authority="iso639-2b" type="text">No linguistic content</languageTerm>
+    </language>
+
+.. code-block:: turtle
+
+    @prefix dcterms: <http://purl.org/dc/terms/>
+
+    <https://example.org/objects/1> dcterms:language <http://id.loc.gov/vocabulary/iso639-2/zxx> ;
+
+language has language subelement with an @type = "code" and value of "zxx"
+--------------------------------------------------------------------------
+
+https://digital.lib.utk.edu/collections/islandora/object/tdh:911/datastream/MODS/view
+
+.. code-block:: xml
+
+    <language>
+        <languageTerm type="code" authority="iso639-2b">zxx</languageTerm>
+    </language>
+
+.. code-block:: turtle
+
+    @prefix dcterms: <http://purl.org/dc/terms/>
+
+    <https://example.org/objects/1> dcterms:language <http://id.loc.gov/vocabulary/iso639-2/zxx> ;
+
+
+
+language has language subelement without a stated @authority and a @code value of "fra"
+---------------------------------------------------------------------------------------
+
+Two questions here along with my proposed:
+
+1. How do we handle any that have no stated authority?
+2. Two volvoices objects use "fra". Is there a difference between fra and fre as codes?
+
+https://digital.lib.utk.edu/collections/islandora/object/volvoices:9928/datastream/MODS/vieww
+
+.. code-block:: xml
+
+    <language>
+        <languageTerm type="code">fra</languageTerm>
+    </language>
+
+.. code-block:: turtle
+
+    @prefix dcterms: <http://purl.org/dc/terms/>
+
+    <https://example.org/objects/1> dcterms:language <http://id.loc.gov/vocabulary/iso639-2/fre> ;
+
+Special Note
+------------
+https://digital.lib.utk.edu/collections/islandora/object/collections:utsmc/datastream/MODS/view
+
+The collection object for utsmc has the follow language XML. While it may not matter with it being a
+collection level object, I wonder how we would approach this if it were something we actually did want
+to migrate.
+
+.. code-block:: xml
+
+    <language>
+        <languageTerm authority="iso639-2b" type="text">English</languageTerm>
+        <languageTerm authority="iso639-2b" type="text">French</languageTerm>
+        <languageTerm authority="iso639-2b" type="text">German</languageTerm>
+        <languageTerm authority="iso639-2b" type="text">Italian</languageTerm>
+        <languageTerm authority="iso639-2b" type="text">Spanish</languageTerm>
+    </language>
+
+.. code-block:: turtle
+
+    @prefix dcterms: <http://purl.org/dc/terms/>
+
+    <https://example.org/objects/1>
+        dcterms:language <http://id.loc.gov/vocabulary/iso639-2/eng> ;
+        dcterms:language <http://id.loc.gov/vocabulary/iso639-2/fre> ;
+        dcterms:language <http://id.loc.gov/vocabulary/iso639-2/ger> ;
+        dcterms:language <http://id.loc.gov/vocabulary/iso639-2/ita> ;
+        dcterms:language <http://id.loc.gov/vocabulary/iso639-2/spa> .


### PR DESCRIPTION
This adds analysis and proposed turtle for language from our current Islandora metadata.

**Note:** the primary question I came across was what to with the items that had a language term code of **fra** (2 items in volvoices) and how these should be handled in relation to those with a common code of **fre**.

- volvoices:9928
- volvoices:11719
