### PR TITLE
Add location analysis

### DIFF
--- a/docs/source/top_level_elements/location.rst
+++ b/docs/source/top_level_elements/location.rst
@@ -8,8 +8,10 @@ This section describes all the different types of location elements that we have
 Distinct Cases
 --------------
 
-physicalLocation with explicit uri
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+physicalLocation with @valueURI
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We have 14302 where a physicalLocation has a valueURI attribute. We will use the URI in replacement of a literal in those cases.
 
 https://digital.lib.utk.edu/collections/islandora/object/egypt:79/datastream/MODS/view
 
@@ -26,8 +28,39 @@ https://digital.lib.utk.edu/collections/islandora/object/egypt:79/datastream/MOD
     <https://example.org/objects/1>
         relators:rps <http://id.loc.gov/authorities/names/no2017033007> .
 
+physicalLocation without @valueURI
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If valueURI is not present, we will use the string literal.
+
+https://digital.lib.utk.edu/collections/islandora/object/egypt:79/datastream/MODS/view
+
+.. code-block:: xml
+
+    <location>
+        <physicalLocation>Blount County Public Library</physicalLocation>
+        <holdingExternal>
+            <holding xsi:schemaLocation="info:ofi/fmt:xml:xsd:iso20775 http://www.loc.gov/standards/iso20775/N130_ISOholdings_v6_1.xsd">
+                <physicalAddress>
+                    <text>City: Maryville</text>
+                    <text>County: Blount County</text>
+                    <text>State: Tennessee</text>
+                </physicalAddress>
+            </holding>
+        </holdingExternal>
+    </location>
+
+.. code-block:: turtle
+
+    @prefix relators: <http://id.loc.gov/vocabulary/relators> .
+
+    <https://example.org/objects/1>
+        relators:rps "Blount County Public Library" .
+
 physicalLocation as string (special collections)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If we do not have a valueURI for the various strings encompassing University of Tennessee Libraries Special Collections, we would map these to the appropriate URI.
 
 https://digital.lib.utk.edu/collections/islandora/object/roth:4245/datastream/MODS/view
 
@@ -46,6 +79,8 @@ https://digital.lib.utk.edu/collections/islandora/object/roth:4245/datastream/MO
 
 physicalLocation as string (libraries)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Like above, if we do not have a valueURI for the various strings encompassing University of Tennessee Libraries, we would map these to the appropriate URI.
 
 **The University of Tennessee Libraries, Knoxville** 574 instances
 

--- a/docs/source/top_level_elements/location.rst
+++ b/docs/source/top_level_elements/location.rst
@@ -39,6 +39,7 @@ https://digital.lib.utk.edu/collections/islandora/object/roth:4245/datastream/MO
 .. code-block:: turtle
 
     @prefix relators: <http://id.loc.gov/vocabulary/relators> .
+    @prefix relators: <http://id.loc.gov/vocabulary/relators> .
 
     <https://example.org/objects/1> relators:rps <http://id.loc.gov/authorities/names/no2014027633> .
 
@@ -93,13 +94,14 @@ https://digital.lib.utk.edu/collections/islandora/object/scopes:1258/datastream/
         <shelfLocator>Box 5, Folder 8</shelfLocator>
     </location>
 
+In most cases, especially those under our purview, we will likely opt to drop box and folder number references.
+
 .. code-block:: turtle
 
     @prefix relators: <http://id.loc.gov/vocabulary/relators> .
     @prefix opaque: <http://opaquenamespace.org/ns/> .
 
-    <https://example.org/objects/1> relators:rps <http://id.loc.gov/authorities/names/no2014027633> ;
-        opaque:locationShelfLocator "Box 5, Folder 8" .
+    <https://example.org/objects/1> relators:rps <http://id.loc.gov/authorities/names/no2014027633> .
 
 physicalLocation with holdingSimple and holdingExternal
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -131,8 +133,7 @@ https://digital.lib.utk.edu/collections/islandora/object/volvoices:2199/datastre
     @prefix relators: <http://id.loc.gov/vocabulary/relators> .
     @prefix opaque: <http://opaquenamespace.org/ns/> .
 
-    <https://example.org/objects/1> relators:rps "University of Memphis. Special Collections" ;
-        opaque:locationShelfLocator "Manuscript Number 5" .
+    <https://example.org/objects/1> relators:rps "University of Memphis. Special Collections" .
 
 physicalLocation with displayLabel="Address"
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -148,7 +149,7 @@ https://digital.lib.utk.edu/collections/islandora/object/arrow:58/datastream/MOD
         <shelfLocator>Box 36, Folder 14</shelfLocator>
     </location>
 
-*This is one where I'm not sure where to go with.*
+Samvera documentation does demonstrate use of Opaque Namespace **locationShelfLocator** predicate, however, this still under development. Though, we likely do not want to do this for every item in our collections, there may be special cases where we want to use opaquenamespace predicates to note box and folder number and names. If so, we can use **boxNumber**, **boxName**, **folderNumber**, and **folderName**  `opaquenamespace predicates <http://opaquenamespace.org/predicates>`_.
 
 .. code-block:: turtle
 
@@ -156,8 +157,8 @@ https://digital.lib.utk.edu/collections/islandora/object/arrow:58/datastream/MOD
     @prefix opaque: <http://opaquenamespace.org/ns/> .
 
     <https://example.org/objects/1> relators:rps "Pi Beta Phi Fraternity" ;
-        opaque:locationShelfLocator "Box 36, Folder 14" .
-
+        opaque:boxNumber "36" ;
+        opaque:folderNumber "14" .
 
 physicalLocation with displayLabel attributes for Collection and Repository
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -188,7 +189,9 @@ https://digital.lib.utk.edu/collections/islandora/object/arrowmont%3A208/datastr
 url with a preview
 ^^^^^^^^^^^^^^^^^^
 
-*These only occur in volvoices. Obviously, this is a case where the turtle object URIs will be relative to the new platform.*
+The URIs referenced are relative to our current system and would not be migrated. Translating this to RDF would be self-referential and not descriptive metadata.
+
+**This can be dropped.**
 
 https://digital.lib.utk.edu/collections/islandora/object/volvoices%3A9999
 
@@ -198,11 +201,3 @@ https://digital.lib.utk.edu/collections/islandora/object/volvoices%3A9999
         <url access="object in context" usage="primary display">https://digital.lib.utk.edu/collections/islandora/object/volvoices%3A9999</url>
         <url access="preview">https://digital.lib.utk.edu/collections/islandora/object/volvoices%3A9999/datastream/TN/view</url>
     </location>
-
-.. code-block:: turtle
-
-    @prefix edm: <http://www.europeana.eu/schemas/edm/> .
-
-    <https://example.org/objects/1> edm:isShownAt <https://digital.lib.utk.edu/placeholder/shownat/uri> ;
-        edm:preview <https://digital.lib.utk.edu/placeholder/preview/uri> ;
-        edm:object <https://digital.lib.utk.edu/placeholder/object/uri> .

--- a/docs/source/top_level_elements/location.rst
+++ b/docs/source/top_level_elements/location.rst
@@ -9,7 +9,7 @@ Distinct Cases
 --------------
 
 physicalLocation with explicit uri
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 https://digital.lib.utk.edu/collections/islandora/object/egypt:79/datastream/MODS/view
 
@@ -26,7 +26,7 @@ https://digital.lib.utk.edu/collections/islandora/object/egypt:79/datastream/MOD
     <https://example.org/objects/1> relators:rps <http://id.loc.gov/authorities/names/no2017033007> .
 
 physicalLocation as string (special collections)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 https://digital.lib.utk.edu/collections/islandora/object/roth:4245/datastream/MODS/view
 
@@ -43,7 +43,7 @@ https://digital.lib.utk.edu/collections/islandora/object/roth:4245/datastream/MO
     <https://example.org/objects/1> relators:rps <http://id.loc.gov/authorities/names/no2014027633> .
 
 physicalLocation as string (libraries)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **The University of Tennessee Libraries, Knoxville** 574 instances
 
@@ -82,7 +82,7 @@ https://digital.lib.utk.edu/collections/islandora/object/tdh:8781/datastream/MOD
     <https://example.org/objects/1> relators:rps <http://id.loc.gov/authorities/names/n80003889> .
 
 physicalLocation and shelfLocator
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 https://digital.lib.utk.edu/collections/islandora/object/scopes:1258/datastream/MODS/view
 
@@ -102,7 +102,7 @@ https://digital.lib.utk.edu/collections/islandora/object/scopes:1258/datastream/
         opaque:locationShelfLocator "Box 5, Folder 8" .
 
 physicalLocation with holdingSimple and holdingExternal
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 https://digital.lib.utk.edu/collections/islandora/object/volvoices:2199/datastream/MODS/view
 
@@ -135,7 +135,7 @@ https://digital.lib.utk.edu/collections/islandora/object/volvoices:2199/datastre
         opaque:locationShelfLocator "Manuscript Number 5" .
 
 physicalLocation with displayLabel="Address"
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 https://digital.lib.utk.edu/collections/islandora/object/arrow:58/datastream/MODS/view
 
@@ -160,7 +160,7 @@ https://digital.lib.utk.edu/collections/islandora/object/arrow:58/datastream/MOD
 
 
 physicalLocation with displayLabel attributes for Collection and Repository
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 https://digital.lib.utk.edu/collections/islandora/object/arrowmont%3A208/datastream/MODS/view
 

--- a/docs/source/top_level_elements/location.rst
+++ b/docs/source/top_level_elements/location.rst
@@ -1,0 +1,208 @@
+language
+========
+
+About
+-----
+This section describes all the different types of location elements that we have in our Islandora repository right now.
+
+Distinct Cases
+--------------
+
+physicaLocation with explicit uri
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+https://digital.lib.utk.edu/collections/islandora/object/egypt:79/datastream/MODS/view
+
+.. code-block:: xml
+
+    <location>
+        <physicalLocation valueURI="http://id.loc.gov/authorities/names/no2017033007">Frank H. McClung Museum of Natural History and Culture</physicalLocation>
+    </location>
+
+.. code-block:: turtle
+
+    @prefix relators: <http://id.loc.gov/vocabulary/relators> .
+
+    <https://example.org/objects/1> relators:rps <http://id.loc.gov/authorities/names/no2017033007> .
+
+physicaLocation as string (special collections)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+https://digital.lib.utk.edu/collections/islandora/object/roth:4245/datastream/MODS/view
+
+.. code-block:: xml
+
+    <location>
+        <physicalLocation>University of Tennessee, Knoxville. Special Collections</physicalLocation>
+    </location>
+
+.. code-block:: turtle
+
+    @prefix relators: <http://id.loc.gov/vocabulary/relators> .
+
+    <https://example.org/objects/1> relators:rps <http://id.loc.gov/authorities/names/no2014027633> .
+
+physicaLocation as string (libraries)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**The University of Tennessee Libraries, Knoxville** 574 instances
+
+https://digital.lib.utk.edu/collections/islandora/object/fbpro:94819/datastream/MODS/view
+
+.. code-block:: xml
+
+    <location>
+        <physicalLocation>The University of Tennessee Libraries, Knoxville</physicalLocation>
+    </location>
+
+**University of Tennessee Knoxville. Libraries** 664 instances
+
+https://digital.lib.utk.edu/collections/islandora/object/tatum:609/datastream/MODS/view
+
+.. code-block:: xml
+
+    <location>
+        <physicalLocation>University of Tennessee Knoxville. Libraries</physicalLocation>
+    </location>
+
+**University of Tennesse Knoxville. Libraries** 397 instances
+
+https://digital.lib.utk.edu/collections/islandora/object/tdh:8781/datastream/MODS/view
+
+.. code-block:: xml
+
+    <location>
+        <physicalLocation>University of Tennesse Knoxville. Libraries</physicalLocation>
+    </location>
+
+.. code-block:: turtle
+
+    @prefix relators: <http://id.loc.gov/vocabulary/relators> .
+
+    <https://example.org/objects/1> relators:rps <http://id.loc.gov/authorities/names/n80003889> .
+
+physicaLocation and shelfLocator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+https://digital.lib.utk.edu/collections/islandora/object/scopes:1258/datastream/MODS/view
+
+.. code-block:: xml
+
+    <location>
+        <physicalLocation valueURI="http://id.loc.gov/authorities/names/no2014027633">University of Tennessee, Knoxville. Special Collections</physicalLocation>
+        <shelfLocator>Box 5, Folder 8</shelfLocator>
+    </location>
+
+.. code-block:: turtle
+
+    @prefix relators: <http://id.loc.gov/vocabulary/relators> .
+    @prefix opaque: <http://opaquenamespace.org/ns/> .
+
+    <https://example.org/objects/1> relators:rps <http://id.loc.gov/authorities/names/no2014027633> ;
+        opaque:locationShelfLocator "Box 5, Folder 8" .
+
+physicaLocation with holdingSimple and holdingExternal
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+https://digital.lib.utk.edu/collections/islandora/object/volvoices:2199/datastream/MODS/view
+
+.. code-block:: xml
+
+    <location>
+        <physicalLocation>University of Memphis. Special Collections</physicalLocation>
+        <holdingSimple>
+            <copyInformation>
+                <shelfLocator>Manuscript Number 5</shelfLocator>
+            </copyInformation>
+        </holdingSimple>
+        <holdingExternal>
+            <holding xsi:schemaLocation="info:ofi/fmt:xml:xsd:iso20775 http://www.loc.gov/standards/iso20775/N130_ISOholdings_v6_1.xsd">
+                <physicalAddress>
+                    <text>City: Memphis</text>
+                    <text>County: Shelby County</text>
+                    <text>State: Tennessee</text>
+                </physicalAddress>
+            </holding>
+        </holdingExternal>
+    </location>
+
+.. code-block:: turtle
+
+    @prefix relators: <http://id.loc.gov/vocabulary/relators> .
+    @prefix opaque: <http://opaquenamespace.org/ns/> .
+
+    <https://example.org/objects/1> relators:rps "University of Memphis. Special Collections" ;
+        opaque:locationShelfLocator "Manuscript Number 5" .
+
+physicaLocation with displayLabel="Address"
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+https://digital.lib.utk.edu/collections/islandora/object/arrow:58/datastream/MODS/view
+
+.. code-block:: xml
+
+
+    <location>
+        <physicalLocation>Pi Beta Phi Fraternity</physicalLocation>
+        <physicalLocation displayLabel="Address">1154 Town and Country Commons Drive, Town and Country, Missouri 63017</physicalLocation>
+        <shelfLocator>Box 36, Folder 14</shelfLocator>
+    </location>
+
+*This is one where I'm not sure where to go with.*
+
+.. code-block:: turtle
+
+    @prefix relators: <http://id.loc.gov/vocabulary/relators> .
+    @prefix opaque: <http://opaquenamespace.org/ns/> .
+
+    <https://example.org/objects/1> relators:rps "Pi Beta Phi Fraternity" ;
+        opaque:locationShelfLocator "Box 36, Folder 14" .
+
+
+physicaLocation with displayLabel attributes for Collection and Repository
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+https://digital.lib.utk.edu/collections/islandora/object/arrowmont%3A208/datastream/MODS/view
+
+.. code-block:: xml
+
+
+    <location>
+        <physicalLocation displayLabel="Collection">Archives Collection</physicalLocation>
+        <physicalLocation displayLabel="Repository">Arrowmont School of Arts and Crafts</physicalLocation>
+        <physicalLocation displayLabel="Detailed Location"/>
+        <physicalLocation displayLabel="City">Gatlinburg</physicalLocation>
+        <physicalLocation displayLabel="State">Tennessee</physicalLocation>
+    </location>
+
+*I am not sold on whether retaining the Archives Collection string is necessary. I don't think the city and state are necessary if a URI is used instead of string.*
+
+.. code-block:: turtle
+
+    @prefix relators: <http://id.loc.gov/vocabulary/relators> .
+    @prefix dbo: <http://dbpedia.org/ontology/> .
+
+    <https://example.org/objects/1> relators:rps <http://id.loc.gov/authorities/names/no2001080757> ;
+        dbo:collection "Archives Collection" .
+
+url with a preview
+^^^^^^^^^^^^^^^^^^
+
+*These only occur in volvoices. Obviously, this is a case where the turtle object URIs will need to be adjusted to their new locations.*
+
+https://digital.lib.utk.edu/collections/islandora/object/volvoices%3A9999
+
+.. code-block:: xml
+
+    <location>
+        <url access="object in context" usage="primary display">https://digital.lib.utk.edu/collections/islandora/object/volvoices%3A9999</url>
+        <url access="preview">https://digital.lib.utk.edu/collections/islandora/object/volvoices%3A9999/datastream/TN/view</url>
+    </location>
+
+.. code-block:: turtle
+
+    @prefix edm: <http://www.europeana.eu/schemas/edm/> .
+
+    <https://example.org/objects/1> edm:isShownAt <https://digital.lib.utk.edu/collections/islandora/object/volvoices%3A9999> ;
+        edm:preview <https://digital.lib.utk.edu/collections/islandora/object/volvoices%3A9999/datastream/TN/view> ;
+        edm:object <https://digital.lib.utk.edu/collections/islandora/object/volvoices%3A9999/datastream/OBJ/view> .

--- a/docs/source/top_level_elements/location.rst
+++ b/docs/source/top_level_elements/location.rst
@@ -188,7 +188,7 @@ https://digital.lib.utk.edu/collections/islandora/object/arrowmont%3A208/datastr
 url with a preview
 ^^^^^^^^^^^^^^^^^^
 
-*These only occur in volvoices. Obviously, this is a case where the turtle object URIs will need to be adjusted to their new locations.*
+*These only occur in volvoices. Obviously, this is a case where the turtle object URIs will be relative to the new platform.*
 
 https://digital.lib.utk.edu/collections/islandora/object/volvoices%3A9999
 
@@ -203,6 +203,6 @@ https://digital.lib.utk.edu/collections/islandora/object/volvoices%3A9999
 
     @prefix edm: <http://www.europeana.eu/schemas/edm/> .
 
-    <https://example.org/objects/1> edm:isShownAt <https://digital.lib.utk.edu/collections/islandora/object/volvoices%3A9999> ;
-        edm:preview <https://digital.lib.utk.edu/collections/islandora/object/volvoices%3A9999/datastream/TN/view> ;
-        edm:object <https://digital.lib.utk.edu/collections/islandora/object/volvoices%3A9999/datastream/OBJ/view> .
+    <https://example.org/objects/1> edm:isShownAt <https://digital.lib.utk.edu/placeholder/shownat/uri> ;
+        edm:preview <https://digital.lib.utk.edu/placeholder/preview/uri> ;
+        edm:object <https://digital.lib.utk.edu/placeholder/object/uri> .

--- a/docs/source/top_level_elements/location.rst
+++ b/docs/source/top_level_elements/location.rst
@@ -23,7 +23,8 @@ https://digital.lib.utk.edu/collections/islandora/object/egypt:79/datastream/MOD
 
     @prefix relators: <http://id.loc.gov/vocabulary/relators> .
 
-    <https://example.org/objects/1> relators:rps <http://id.loc.gov/authorities/names/no2017033007> .
+    <https://example.org/objects/1>
+        relators:rps <http://id.loc.gov/authorities/names/no2017033007> .
 
 physicalLocation as string (special collections)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,9 +40,9 @@ https://digital.lib.utk.edu/collections/islandora/object/roth:4245/datastream/MO
 .. code-block:: turtle
 
     @prefix relators: <http://id.loc.gov/vocabulary/relators> .
-    @prefix relators: <http://id.loc.gov/vocabulary/relators> .
 
-    <https://example.org/objects/1> relators:rps <http://id.loc.gov/authorities/names/no2014027633> .
+    <https://example.org/objects/1>
+        relators:rps <http://id.loc.gov/authorities/names/no2014027633> .
 
 physicalLocation as string (libraries)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -80,10 +81,13 @@ https://digital.lib.utk.edu/collections/islandora/object/tdh:8781/datastream/MOD
 
     @prefix relators: <http://id.loc.gov/vocabulary/relators> .
 
-    <https://example.org/objects/1> relators:rps <http://id.loc.gov/authorities/names/n80003889> .
+    <https://example.org/objects/1>
+        relators:rps <http://id.loc.gov/authorities/names/n80003889> .
 
 physicalLocation and shelfLocator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In cases the physical location is under the purview of University of Tennessee Libraries or University of Tennessee Libraries Special Collections, we will opt to drop shelfLocator strings.
 
 https://digital.lib.utk.edu/collections/islandora/object/scopes:1258/datastream/MODS/view
 
@@ -94,16 +98,50 @@ https://digital.lib.utk.edu/collections/islandora/object/scopes:1258/datastream/
         <shelfLocator>Box 5, Folder 8</shelfLocator>
     </location>
 
-In most cases, especially those under our purview, we will likely opt to drop box and folder number references.
-
 .. code-block:: turtle
 
     @prefix relators: <http://id.loc.gov/vocabulary/relators> .
 
-    <https://example.org/objects/1> relators:rps <http://id.loc.gov/authorities/names/no2014027633> .
+    <https://example.org/objects/1>
+        relators:rps <http://id.loc.gov/authorities/names/no2014027633> .
+
+We will translate that shelfLocator string to a skos:note if outside UT Libraries.
+
+https://digital.lib.utk.edu/collections/islandora/object/volvoices:2136/datastream/MODS/view
+
+.. code-block:: xml
+
+    <location>
+        <physicalLocation>Cleveland State Community College</physicalLocation>
+        <holdingSimple>
+            <copyInformation>
+                <shelfLocator>Photograph Collection 2, People</shelfLocator>
+            </copyInformation>
+        </holdingSimple>
+        <holdingExternal>
+            <holding xsi:schemaLocation="info:ofi/fmt:xml:xsd:iso20775 http://www.loc.gov/standards/iso20775/N130_ISOholdings_v6_1.xsd">
+                <physicalAddress>
+                    <text>City: Cleveland</text>
+                    <text>County: Bradley County</text>
+                    <text>State: Tennessee</text>
+                </physicalAddress>
+            </holding>
+        </holdingExternal>
+    </location>
+
+.. code-block:: turtle
+
+    @prefix relators: <http://id.loc.gov/vocabulary/relators> .
+    @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+    <https://example.org/objects/1>
+        relators:rps "Cleveland State Community College" ;
+        skos:note "Shelf locator: Photograph Collection 2, People" .
 
 physicalLocation with holdingSimple and holdingExternal
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+All of extra data under the holdingExternal subelement can be dropped.
 
 https://digital.lib.utk.edu/collections/islandora/object/volvoices:2199/datastream/MODS/view
 
@@ -130,16 +168,20 @@ https://digital.lib.utk.edu/collections/islandora/object/volvoices:2199/datastre
 .. code-block:: turtle
 
     @prefix relators: <http://id.loc.gov/vocabulary/relators> .
+    @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 
-    <https://example.org/objects/1> relators:rps "University of Memphis. Special Collections" .
+    <https://example.org/objects/1>
+        relators:rps "University of Memphis. Special Collections" ;
+        skos:note "Shelf locator: Manuscript Number 5" .
 
 physicalLocation with displayLabel="Address"
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+We will opt to drop physicalLocation subelements with a displayLabel of *Address*.
+
 https://digital.lib.utk.edu/collections/islandora/object/arrow:58/datastream/MODS/view
 
 .. code-block:: xml
-
 
     <location>
         <physicalLocation>Pi Beta Phi Fraternity</physicalLocation>
@@ -147,24 +189,23 @@ https://digital.lib.utk.edu/collections/islandora/object/arrow:58/datastream/MOD
         <shelfLocator>Box 36, Folder 14</shelfLocator>
     </location>
 
-Samvera documentation does demonstrate use of Opaque Namespace **locationShelfLocator** predicate, however, this may still be under development or maybe even abandoned. Though, we likely do not want to do this for every item in our collections, there may be special cases where we want to use predicates to reference box and folder number and names. If so, we can use **boxNumber**, **boxName**, **folderNumber**, and **folderName**  `opaquenamespace predicates <http://opaquenamespace.org/predicates>`_.
-
 .. code-block:: turtle
 
     @prefix relators: <http://id.loc.gov/vocabulary/relators> .
-    @prefix opaque: <http://opaquenamespace.org/ns/> .
+    @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 
-    <https://example.org/objects/1> relators:rps "Pi Beta Phi Fraternity" ;
-        opaque:boxNumber "36" ;
-        opaque:folderNumber "14" .
+    <https://example.org/objects/1>
+        relators:rps "Pi Beta Phi Fraternity" ;
+        skos:note "Shelf locator: Box 36, Folder 14" .
 
 physicalLocation with displayLabel attributes for Collection and Repository
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+We have some cases *arrowmont* and *arrsimple* where a displayLabel="Collection" contains a string of **Archives Collection**. In these instances, *dbo:collection* will be used to retain that information. Other than *displayLabel="Repository"*, All other physicalLocation subelements with a displayLabel will be dropped.
+
 https://digital.lib.utk.edu/collections/islandora/object/arrowmont%3A208/datastream/MODS/view
 
 .. code-block:: xml
-
 
     <location>
         <physicalLocation displayLabel="Collection">Archives Collection</physicalLocation>
@@ -174,14 +215,13 @@ https://digital.lib.utk.edu/collections/islandora/object/arrowmont%3A208/datastr
         <physicalLocation displayLabel="State">Tennessee</physicalLocation>
     </location>
 
-*I am not sold on whether retaining the Archives Collection string is necessary. I don't think the city and state are necessary if a URI is used instead of string.*
-
 .. code-block:: turtle
 
     @prefix relators: <http://id.loc.gov/vocabulary/relators> .
     @prefix dbo: <http://dbpedia.org/ontology/> .
 
-    <https://example.org/objects/1> relators:rps <http://id.loc.gov/authorities/names/no2001080757> ;
+    <https://example.org/objects/1>
+        relators:rps <http://id.loc.gov/authorities/names/no2001080757> ;
         dbo:collection "Archives Collection" .
 
 url with a preview

--- a/docs/source/top_level_elements/location.rst
+++ b/docs/source/top_level_elements/location.rst
@@ -1,4 +1,4 @@
-language
+location
 ========
 
 About
@@ -8,7 +8,7 @@ This section describes all the different types of location elements that we have
 Distinct Cases
 --------------
 
-physicaLocation with explicit uri
+physicalLocation with explicit uri
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 https://digital.lib.utk.edu/collections/islandora/object/egypt:79/datastream/MODS/view
@@ -25,7 +25,7 @@ https://digital.lib.utk.edu/collections/islandora/object/egypt:79/datastream/MOD
 
     <https://example.org/objects/1> relators:rps <http://id.loc.gov/authorities/names/no2017033007> .
 
-physicaLocation as string (special collections)
+physicalLocation as string (special collections)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 https://digital.lib.utk.edu/collections/islandora/object/roth:4245/datastream/MODS/view
@@ -42,7 +42,7 @@ https://digital.lib.utk.edu/collections/islandora/object/roth:4245/datastream/MO
 
     <https://example.org/objects/1> relators:rps <http://id.loc.gov/authorities/names/no2014027633> .
 
-physicaLocation as string (libraries)
+physicalLocation as string (libraries)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **The University of Tennessee Libraries, Knoxville** 574 instances
@@ -81,7 +81,7 @@ https://digital.lib.utk.edu/collections/islandora/object/tdh:8781/datastream/MOD
 
     <https://example.org/objects/1> relators:rps <http://id.loc.gov/authorities/names/n80003889> .
 
-physicaLocation and shelfLocator
+physicalLocation and shelfLocator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 https://digital.lib.utk.edu/collections/islandora/object/scopes:1258/datastream/MODS/view
@@ -101,7 +101,7 @@ https://digital.lib.utk.edu/collections/islandora/object/scopes:1258/datastream/
     <https://example.org/objects/1> relators:rps <http://id.loc.gov/authorities/names/no2014027633> ;
         opaque:locationShelfLocator "Box 5, Folder 8" .
 
-physicaLocation with holdingSimple and holdingExternal
+physicalLocation with holdingSimple and holdingExternal
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 https://digital.lib.utk.edu/collections/islandora/object/volvoices:2199/datastream/MODS/view
@@ -134,7 +134,7 @@ https://digital.lib.utk.edu/collections/islandora/object/volvoices:2199/datastre
     <https://example.org/objects/1> relators:rps "University of Memphis. Special Collections" ;
         opaque:locationShelfLocator "Manuscript Number 5" .
 
-physicaLocation with displayLabel="Address"
+physicalLocation with displayLabel="Address"
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 https://digital.lib.utk.edu/collections/islandora/object/arrow:58/datastream/MODS/view
@@ -159,7 +159,7 @@ https://digital.lib.utk.edu/collections/islandora/object/arrow:58/datastream/MOD
         opaque:locationShelfLocator "Box 36, Folder 14" .
 
 
-physicaLocation with displayLabel attributes for Collection and Repository
+physicalLocation with displayLabel attributes for Collection and Repository
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 https://digital.lib.utk.edu/collections/islandora/object/arrowmont%3A208/datastream/MODS/view

--- a/docs/source/top_level_elements/location.rst
+++ b/docs/source/top_level_elements/location.rst
@@ -99,7 +99,6 @@ In most cases, especially those under our purview, we will likely opt to drop bo
 .. code-block:: turtle
 
     @prefix relators: <http://id.loc.gov/vocabulary/relators> .
-    @prefix opaque: <http://opaquenamespace.org/ns/> .
 
     <https://example.org/objects/1> relators:rps <http://id.loc.gov/authorities/names/no2014027633> .
 
@@ -131,7 +130,6 @@ https://digital.lib.utk.edu/collections/islandora/object/volvoices:2199/datastre
 .. code-block:: turtle
 
     @prefix relators: <http://id.loc.gov/vocabulary/relators> .
-    @prefix opaque: <http://opaquenamespace.org/ns/> .
 
     <https://example.org/objects/1> relators:rps "University of Memphis. Special Collections" .
 

--- a/docs/source/top_level_elements/location.rst
+++ b/docs/source/top_level_elements/location.rst
@@ -149,7 +149,7 @@ https://digital.lib.utk.edu/collections/islandora/object/arrow:58/datastream/MOD
         <shelfLocator>Box 36, Folder 14</shelfLocator>
     </location>
 
-Samvera documentation does demonstrate use of Opaque Namespace **locationShelfLocator** predicate, however, this still under development. Though, we likely do not want to do this for every item in our collections, there may be special cases where we want to use opaquenamespace predicates to note box and folder number and names. If so, we can use **boxNumber**, **boxName**, **folderNumber**, and **folderName**  `opaquenamespace predicates <http://opaquenamespace.org/predicates>`_.
+Samvera documentation does demonstrate use of Opaque Namespace **locationShelfLocator** predicate, however, this may still be under development or maybe even abandoned. Though, we likely do not want to do this for every item in our collections, there may be special cases where we want to use predicates to reference box and folder number and names. If so, we can use **boxNumber**, **boxName**, **folderNumber**, and **folderName**  `opaquenamespace predicates <http://opaquenamespace.org/predicates>`_.
 
 .. code-block:: turtle
 


### PR DESCRIPTION
This adds analysis and proposed turtle for **location** from our current Islandora metadata. 

There are a few instances that stumped me a bit.[ Item's with XML like the below](https://github.com/UTKcataloging/mods_to_rdf/blob/locationAnalysis/docs/source/top_level_elements/location.rst#physicalocation-with-holdingsimple-and-holdingexternal) leave me wondering what should be retained. Either way, I understand this is just a the analysis step of this element, and so, turtle does not need to be perfect yet. I expect we will review this further and make modifications following the 9/18 Mods to RDF meeting.

https://digital.lib.utk.edu/collections/islandora/object/volvoices:2199/datastream/MODS/view

```
    <location>
        <physicalLocation>University of Memphis. Special Collections</physicalLocation>
        <holdingSimple>
            <copyInformation>
                <shelfLocator>Manuscript Number 5</shelfLocator>
            </copyInformation>
        </holdingSimple>
        <holdingExternal>
            <holding xsi:schemaLocation="info:ofi/fmt:xml:xsd:iso20775 http://www.loc.gov/standards/iso20775/N130_ISOholdings_v6_1.xsd">
                <physicalAddress>
                    <text>City: Memphis</text>
                    <text>County: Shelby County</text>
                    <text>State: Tennessee</text>
                </physicalAddress>
            </holding>
        </holdingExternal>
    </location>
```

