### PR TITLE
Install minimal Read the Docs theme.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Install Sphinx
         run: sudo apt-get install python3-sphinx
+      - name: Install Read the Docs theme
+        run: sudo pip install sphinx-rtd-theme
       - name: Install our application with pipenv
         uses: VaultVulp/action-pipenv@v2.0.1
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
         uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "docs/"
-          pre-build-command: "pip install && pip install sphinx-rtd-theme pipenv && pipenv install && pipenv shell"
+          pre-build-command: "pip install sphinx-rtd-theme && pip install pipenv && pipenv install && pipenv shell"
           build-command: "make html"
       - name: Auto Assign Reviewers
         uses: kentaro-m/auto-assign-action@v1.1.2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
         uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "docs/"
-          pre-build-command: "pip install pipenv && pipenv install && pipenv shell && pip install sphinx-rtd-theme"
+          pre-build-command: "pip install && pip install sphinx-rtd-theme pipenv && pipenv install && pipenv shell"
           build-command: "make html"
       - name: Auto Assign Reviewers
         uses: kentaro-m/auto-assign-action@v1.1.2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
         uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "docs/"
-          pre-build-command: "pip install pipenv && pipenv install && pipenv shell"
+          pre-build-command: "pip install pipenv && pipenv install && pipenv shell && pip install sphinx-rtd-theme"
           build-command: "make html"
       - name: Auto Assign Reviewers
         uses: kentaro-m/auto-assign-action@v1.1.2

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,6 +16,7 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+import sphinx_rtd_theme
 
 # -- Project information -----------------------------------------------------
 
@@ -45,6 +46,7 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.imgmath',
     'sphinx.ext.viewcode',
+    "sphinx_rtd_theme"
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -80,7 +82,7 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
What Does this Do?
==================

Installs a minimally configured Read the Docs theme for the MODS to RDF document.

How Should This Be Tested?
==========================

- Checkout my changes to the `build.yml` and the `conf.py`
- Review **build** run [#279](https://github.com/UTKcataloging/mods_to_rdf/runs/1685631869)
- I've setup a dummy doc you can see that is watching the _rtd_ branch, you can see that here: https://dumbme.readthedocs.io (I'll tear down after the merge)

Additional Notes
================
Let me know if you think we should customize this further. Things look pretty good to me right now but maybe y'all have some better ideas.