### PR TITLE
Add creative commons notes.

### DIFF
--- a/docs/source/contents/4_draft_mapping.rst
+++ b/docs/source/contents/4_draft_mapping.rst
@@ -5206,8 +5206,7 @@ This means:
 Justification
 ^^^^^^^^^^^^^
 
-DPLA maps both CC licenses and Rights Statements to `edm:rights`. So does Samvera. Presently only the Heilman Collection
-includes a CC license.
+DPLA maps both CC licenses and Rights Statements to `edm:rights`. So does Samvera.
 
 Creative Commons licenses should me content negotiable and valid for JSON-LD and IIIF.
 

--- a/docs/source/contents/4_draft_mapping.rst
+++ b/docs/source/contents/4_draft_mapping.rst
@@ -5210,7 +5210,7 @@ Justification
 
 DPLA maps both CC licenses and Rights Statements to `edm:rights`. So does Samvera.
 
-Creative Commons licenses should me content negotiable and valid for JSON-LD and IIIF.
+Creative Commons licenses should be content negotiable and valid for JSON-LD and IIIF.
 
 XPath
 ^^^^^

--- a/docs/source/contents/4_draft_mapping.rst
+++ b/docs/source/contents/4_draft_mapping.rst
@@ -5194,11 +5194,22 @@ or one of the CC licenses. These values are used to provide users with standard 
 status of an item and how or if it can be reused. These values are currently displayed in a facet and are recommended for
 sharing with DPLA.
 
+All creative commons licenses should be content negotiable and valid.  For this to happen, this pattern must be followed:
+
+:code:`http://creativecommons.org/licenses/*/*/rdf`
+
+This means:
+
+* Use :code:`http` instead of :code:`https` as the protocol (for content negotiation and validity)
+* End in :code:`/rdf` (for content negotiation)
+
 Justification
 ^^^^^^^^^^^^^
 
-DPLA maps both CC licenses and Rights Statements to `edm:rights`. So does Samvera. Presently only the Heilman Collection includes
-a CC license.
+DPLA maps both CC licenses and Rights Statements to `edm:rights`. So does Samvera. Presently only the Heilman Collection
+includes a CC license.
+
+Creative Commons licenses should me content negotiable and valid for JSON-LD and IIIF.
 
 XPath
 ^^^^^

--- a/docs/source/contents/4_draft_mapping.rst
+++ b/docs/source/contents/4_draft_mapping.rst
@@ -5194,9 +5194,11 @@ or one of the CC licenses. These values are used to provide users with standard 
 status of an item and how or if it can be reused. These values are currently displayed in a facet and are recommended for
 sharing with DPLA.
 
-All creative commons licenses should be content negotiable and valid.  For this to happen, this pattern must be followed:
+All creative commons licenses should be content negotiable and valid.  For this to happen, one of these two patterns
+must be followed:
 
-:code:`http://creativecommons.org/licenses/*/*/rdf`
+* :code:`http://creativecommons.org/licenses/*/*/rdf`
+* :code:`http://creativecommons.org/publicdomain/mark/*/rdf`
 
 This means:
 


### PR DESCRIPTION
**JIRA Issue**: `EXHIBIT-94 <https://jirautk.atlassian.net/browse/EXHIBIT-94>`_

What Does this Do?
==================

We have some Creative Commons licenses that aren't valid for IIIF and are not content negotiable.  This adds a note and justification for what a CC license should look like to be both valid and content negotiable.

How Should This Be Tested?
==========================

Review the change.  Does it make sense? Are there questions.

Additional Notes
================

I haven't done an investigation of all our CC licenses but any manifest that uses a CC license that doesn't follow the pattern listed will fail IIIF validation.  Furthermore, if we are using HTTPS instead of HTTP, the license is not content negotiable and also not valid to IIIF.
