### PR TITLE
Remove bootstrap for required extras.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
             "sphinxcontrib-napoleon >= 0.7",
             "sphinx-markdown-tables >= 0.0.9",
             "recommonmark >=0.5.0",
-            "sphinx-bootstrap-theme >= 0.6.5",
         ]
     },
     classifiers=[


### PR DESCRIPTION
What Does this Do?
==================

Docs builds are currently failing because of an unused requirement in the build instructions.  This removes it.

How Should This Be Tested?
==========================

You can read the docs build log if you want to see why I'm doing this and why I think this will fix it.

Additional Notes
================

That's it. :shipit: 
